### PR TITLE
improve performance by not using memorizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "repository": "thenables/composition",
   "dependencies": {
     "co": "^4.0.2",
-    "memorizer": "^1.0.0",
     "native-or-bluebird": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
memorizer module will make V8 deoptimize Wrap class

`npm run bench` result:
before: 16,018 op/s
after: 26,814 op/s

related topic: V8 hidden class