### PR TITLE
fix bug

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,25 @@ it('should support delegating-yielding a random value', function () {
   })
 })
 
+it('should support return another wrap', function (done) {
+  var i = 0
+  var stack = [
+    function (next) {
+      i++;
+      return next
+    },
+    function (next) {
+      i++;
+      return next
+    }
+  ]
+
+  return compose(stack)().then(function () {
+    assert.equal(i, 2)
+    done()
+  })
+})
+
 it('should support an empty array', function () {
   return compose([])().then(function () {
 


### PR DESCRIPTION
the bug is introduced from pull request #5 (pull request did eliminate
V8 deoptimization, but did not do memorization)

the bug will cause infinite recursion with following middleware:
```js
function middleware(next) {
  return next
}
```

* a test is added
* this bug fix did not affect bench result